### PR TITLE
Adds new stackhawk configuration file for github actions tutorial

### DIFF
--- a/stackhawk-actions.yml
+++ b/stackhawk-actions.yml
@@ -1,0 +1,63 @@
+app:
+  # Update your applicationId
+  applicationId: ${APP_ID:8454c127-64aa-490e-a151-54ae287ee8f1}
+  env: ${APP_ENV:GitHub Actions}
+  host: ${APP_HOST:https://localhost:9000}
+  excludePaths:
+    - "/logout"
+  #    - "/login-form-multi"
+  #    - "/login-code"
+  antiCsrfParam: "_csrf"
+  # Configure Basic Authentication
+  authentication:
+    loggedInIndicator: "\\QSign Out\\E"
+    loggedOutIndicator: ".*Location:.*/login.*"
+    usernamePassword:
+      type: FORM
+      loginPath: /login
+      loginPagePath: /login
+      usernameField: username
+      passwordField: password
+      scanUsername: "user"
+      scanPassword: "password"
+    cookieAuthorization:
+      cookieNames:
+        - "JSESSIONID"
+    testPath:
+      path: /search
+      success: "HTTP.*200.*"
+    # Utilize OpenAPI Spec, Custom data & Faker
+    openApiConf:
+    # path: /openapi
+    filePath: openapi.yaml
+    fakerEnabled: true #default false
+    # includeAllMethods: true
+    includedMethods:
+      - POST
+      - PUT
+    customVariables:
+      - field: text
+        values:
+          - "$faker:uuid"
+      - field: searchText
+        values:
+          - "$faker:Crypto.sha512"
+          - "Donec ullamcorper nulla non metus auctor fringilla."
+      - field: username
+        values:
+          - "Andy Dwyer"
+      - field: password
+        values:
+          - "$faker:password"
+hawk:
+  spider:
+    maxDurationMinutes: 5
+#  config:
+#    - "scanner.analyser.redirectEqualsNotFound=false"
+#    - "scanner.analyser.followRedirect=true"
+# Grab Commit SHA and Branch name
+tags:
+  - name: _STACKHAWK_GIT_COMMIT_SHA
+    value: ${COMMIT_SHA:}
+  - name: _STACKHAWK_GIT_BRANCH
+    value: ${BRANCH_NAME:}


### PR DESCRIPTION
After meeting with KC and talking to him about the ramifications of adding the GitHub Actions workflow file to the sample project for the new tutorial I'm writing, I have decided to only add the HawkScan configuration file. The user will add the workflow file during the tutorial to their fork only. This should protect the project so others can use it for demo purposes. The new HawkScan configuration file is named stackhawk-actions.yml, so to keep it differentiated from the other HawkScan config files. Hopefully, after this update is made, I can get the tutorial published.