### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Java Spring Vulny is a simple application that combines the power and sophistica
 ## Building and Running in IDE/commandline
 ```shell script
 # run the postgresql db so you can have SQLi
-docker-compose up -d db
+docker compose up -d db
 # run the application in debug mode or run mode with the vm option to activate the profile
 # -Dspring.profiles.active=postgresql
 
@@ -16,12 +16,12 @@ docker-compose up -d db
 
 ### Build
 ```shell script
-docker-compose build
+docker compose build
 ```
 
 ### Run docker
 ```shell script
-docker-compose up -d
+docker compose up -d
 ```
 
 ## Building and Running Without Docker
@@ -69,7 +69,7 @@ Once the app starts up, you can reach it at [https://localhost:9000](https://loc
 You can log in to the application with the following credentials:
 
 ```
-    username: janesmith
+    username: user
     password: password
 ```
 


### PR DESCRIPTION
I updated the docker commands. 

As of Docker Compose v2, `docker-compose` (with a hyphen) has been integrated into the Docker CLI and is now accessed as `docker compose` (without a hyphen). This change makes Docker Compose a native Docker command.

Also fixed the user/pass to login to the app

### How does the make you feel?
![Wooooooo](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExb2lpbmUxaWc5d3N6YWtscGZ6MGJkZmFiOHE3eTdybGQ2ODZpd292dSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Q9FGOQewX92eRRO9Qi/giphy.gif)